### PR TITLE
Update php.ini

### DIFF
--- a/config/php.ini
+++ b/config/php.ini
@@ -1884,7 +1884,7 @@ opcache.enable_cli=1
 opcache.memory_consumption=128
 
 ; The amount of memory for interned strings in Mbytes.
-opcache.interned_strings_buffer=8
+opcache.interned_strings_buffer=16
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; Only numbers between 200 and 100000 are allowed.


### PR DESCRIPTION
this updates the opcache setting to 16 to fix the health & security notice from Nextcloud:

"The PHP OPcache module is not properly configured. See the documentation :arrow_upper_right: 1 for more information.
The OPcache interned strings buffer is nearly full. To assure that repeating strings can be effectively cached, it is recommended to apply opcache.interned_strings_buffer to your PHP configuration with a value higher than 8."