### PR TITLE
distinguish a failed upgrade from one still in progress

### DIFF
--- a/cli/cmd/repair-service/main.go
+++ b/cli/cmd/repair-service/main.go
@@ -70,6 +70,22 @@ func main() {
 			logger.Info("refresh-needed marker absent; skipping heavy post-refresh repair")
 		}
 
+		if len(steps) > 0 {
+			attempt := inst.IncrementRepairAttempts()
+			logger.Info("repair attempt", zap.Int("attempt", attempt), zap.Int("max", installer.MaxRepairAttempts))
+			if attempt > installer.MaxRepairAttempts {
+				logger.Error("giving up after repeated repair attempts; showing upgrade-failed page")
+				if err := inst.ShowUpgradeFailedPage(); err != nil {
+					logger.Error("cannot show upgrade-failed page", zap.Error(err))
+				}
+				srv.MarkDone()
+				return
+			}
+			if err := inst.ShowUpgradingPage(); err != nil {
+				logger.Error("cannot show upgrading page", zap.Error(err))
+			}
+		}
+
 		failed := false
 		for _, s := range steps {
 			done := srv.StartStep(s.name)
@@ -77,6 +93,21 @@ func main() {
 			done(err)
 			if err != nil {
 				failed = true
+			}
+		}
+		if len(steps) > 0 {
+			if failed {
+				logger.Error("repair finished with errors; showing upgrade-failed page")
+				if err := inst.ShowUpgradeFailedPage(); err != nil {
+					logger.Error("cannot show upgrade-failed page", zap.Error(err))
+				}
+			} else {
+				if err := inst.ClearStatusPage(); err != nil {
+					logger.Error("cannot clear status page", zap.Error(err))
+				}
+				if err := inst.ClearRepairAttempts(); err != nil {
+					logger.Error("cannot clear repair attempts", zap.Error(err))
+				}
 			}
 		}
 		if !failed {

--- a/cli/cmd/repair-service/main.go
+++ b/cli/cmd/repair-service/main.go
@@ -46,7 +46,7 @@ func main() {
 			fn   func() error
 		}
 		var steps []step
-		ldapDeferred := inst.NeedsDbUpgrade()
+		ldapDeferred := inst.LdapDeferred()
 		if inst.RefreshNeeded() || ldapDeferred {
 			logger.Info("running post-refresh repair", zap.Bool("ldapDeferred", ldapDeferred))
 			steps = []step{
@@ -111,6 +111,9 @@ func main() {
 				}
 				if err := inst.ClearRepairAttempts(); err != nil {
 					logger.Error("cannot clear repair attempts", zap.Error(err))
+				}
+				if err := inst.ClearLdapDeferred(); err != nil {
+					logger.Error("cannot clear ldap-deferred marker", zap.Error(err))
 				}
 			}
 		}

--- a/cli/cmd/repair-service/main.go
+++ b/cli/cmd/repair-service/main.go
@@ -65,6 +65,10 @@ func main() {
 				step{"db-add-missing-columns", inst.RunDbAddMissingColumns},
 				step{"db-add-missing-primary-keys", inst.RunDbAddMissingPrimaryKeys},
 				step{"maintenance-repair", inst.RunMaintenanceRepair},
+				// last line of defence: nextcloud left in maintenance mode
+				// serves 503 forever, so never exit the sequence without
+				// trying to clear it, whatever failed above.
+				step{"maintenance-mode-off-final", inst.RunMaintenanceModeOff},
 			)
 		} else {
 			logger.Info("refresh-needed marker absent; skipping heavy post-refresh repair")

--- a/cli/cmd/repair-service/main.go
+++ b/cli/cmd/repair-service/main.go
@@ -65,9 +65,6 @@ func main() {
 				step{"db-add-missing-columns", inst.RunDbAddMissingColumns},
 				step{"db-add-missing-primary-keys", inst.RunDbAddMissingPrimaryKeys},
 				step{"maintenance-repair", inst.RunMaintenanceRepair},
-				// last line of defence: nextcloud left in maintenance mode
-				// serves 503 forever, so never exit the sequence without
-				// trying to clear it, whatever failed above.
 				step{"maintenance-mode-off-final", inst.RunMaintenanceModeOff},
 			)
 		} else {

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +29,11 @@ const (
 	SignalingSecretsFile = "signaling.secrets"
 	ConfigureDoneMarker  = ".configure-done"
 	RefreshNeededMarker  = ".refresh-needed"
+	RepairAttemptsFile   = ".repair-attempts"
+	StatusPageFile       = "syncloud-status.html"
+	UpgradingPage        = "syncloud-maintenance.html"
+	UpgradeFailedPage    = "syncloud-upgrade-failed.html"
+	MaxRepairAttempts    = 3
 )
 
 type Variables struct {
@@ -341,6 +347,54 @@ func (i *Installer) RefreshNeeded() bool {
 
 func (i *Installer) ClearRefreshNeeded() error {
 	if err := os.Remove(path.Join(i.dataDir, RefreshNeededMarker)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// nginx serves this for nextcloud's own 503, so it must say whether the upgrade
+// is still working or has given up - a spinner shown forever reads as progress.
+func (i *Installer) ShowUpgradingPage() error {
+	return i.writeStatusPage(UpgradingPage)
+}
+
+func (i *Installer) ShowUpgradeFailedPage() error {
+	return i.writeStatusPage(UpgradeFailedPage)
+}
+
+func (i *Installer) ClearStatusPage() error {
+	if err := os.Remove(path.Join(i.dataDir, StatusPageFile)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (i *Installer) writeStatusPage(page string) error {
+	return copyFile(path.Join(i.appDir, "config", page), path.Join(i.dataDir, StatusPageFile))
+}
+
+func (i *Installer) RepairAttempts() int {
+	data, err := os.ReadFile(path.Join(i.dataDir, RepairAttemptsFile))
+	if err != nil {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func (i *Installer) IncrementRepairAttempts() int {
+	n := i.RepairAttempts() + 1
+	if err := os.WriteFile(path.Join(i.dataDir, RepairAttemptsFile), []byte(strconv.Itoa(n)+"\n"), 0644); err != nil {
+		i.logger.Error("cannot record repair attempt", zap.Error(err))
+	}
+	return n
+}
+
+func (i *Installer) ClearRepairAttempts() error {
+	if err := os.Remove(path.Join(i.dataDir, RepairAttemptsFile)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -354,9 +354,6 @@ func (i *Installer) ClearRefreshNeeded() error {
 	return nil
 }
 
-// Configure and the daemon must not each decide this for themselves: they ask
-// at different points in the refresh and got different answers, which left the
-// ldap steps running in neither. Configure decides, the daemon obeys.
 func (i *Installer) MarkLdapDeferred() error {
 	return os.WriteFile(path.Join(i.dataDir, LdapDeferredMarker), []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0644)
 }
@@ -373,8 +370,6 @@ func (i *Installer) ClearLdapDeferred() error {
 	return nil
 }
 
-// nginx serves this for nextcloud's own 503, so it must say whether the upgrade
-// is still working or has given up - a spinner shown forever reads as progress.
 func (i *Installer) ShowUpgradingPage() error {
 	return i.writeStatusPage(UpgradingPage)
 }
@@ -472,9 +467,6 @@ func (i *Installer) RunGroupList() error {
 	return err
 }
 
-// Something can re-enable maintenance mode between maintenance-mode-off and
-// here (seen in the wild: apps loaded fine one second earlier, then
-// 'no apps are loaded'), which hides the whole ldap namespace.
 func (i *Installer) RunLdapPromoteSyncloud() error {
 	_, err := i.occ.Run("ldap:promote-group", "syncloud", "-y")
 	if err == nil {
@@ -573,8 +565,6 @@ func (i *Installer) upgrade(storageDir string) (bool, error) {
 	if err := i.prepareStorage(storageDir); err != nil {
 		return false, err
 	}
-	// Only meaningful once the dump is back: post-refresh wipes and re-initdb's
-	// the cluster, so asking before the restore always errors and looks pending.
 	dbUpgradePending := i.NeedsDbUpgrade()
 	i.logger.Info("upgrade: checked schema", zap.Bool("dbUpgradePending", dbUpgradePending))
 	i.logger.Info("upgrade: legacy admin->syncloud ldap mapping fix")

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -30,6 +30,7 @@ const (
 	ConfigureDoneMarker  = ".configure-done"
 	RefreshNeededMarker  = ".refresh-needed"
 	RepairAttemptsFile   = ".repair-attempts"
+	LdapDeferredMarker   = ".ldap-deferred"
 	StatusPageFile       = "syncloud-status.html"
 	UpgradingPage        = "syncloud-maintenance.html"
 	UpgradeFailedPage    = "syncloud-upgrade-failed.html"
@@ -241,9 +242,10 @@ func (i *Installer) Configure() error {
 	}
 	dbUpgradePending := false
 	if i.installed() {
-		dbUpgradePending = i.NeedsDbUpgrade()
-		i.logger.Info("configure: existing install detected, running upgrade", zap.Bool("dbUpgradePending", dbUpgradePending))
-		if err := i.upgrade(storageDir, dbUpgradePending); err != nil {
+		i.logger.Info("configure: existing install detected, running upgrade")
+		var err error
+		dbUpgradePending, err = i.upgrade(storageDir)
+		if err != nil {
 			return err
 		}
 	} else {
@@ -347,6 +349,25 @@ func (i *Installer) RefreshNeeded() bool {
 
 func (i *Installer) ClearRefreshNeeded() error {
 	if err := os.Remove(path.Join(i.dataDir, RefreshNeededMarker)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// Configure and the daemon must not each decide this for themselves: they ask
+// at different points in the refresh and got different answers, which left the
+// ldap steps running in neither. Configure decides, the daemon obeys.
+func (i *Installer) MarkLdapDeferred() error {
+	return os.WriteFile(path.Join(i.dataDir, LdapDeferredMarker), []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0644)
+}
+
+func (i *Installer) LdapDeferred() bool {
+	_, err := os.Stat(path.Join(i.dataDir, LdapDeferredMarker))
+	return err == nil
+}
+
+func (i *Installer) ClearLdapDeferred() error {
+	if err := os.Remove(path.Join(i.dataDir, LdapDeferredMarker)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil
@@ -543,33 +564,43 @@ func (i *Installer) installed() bool {
 	return strings.Contains(string(data), "installed")
 }
 
-func (i *Installer) upgrade(storageDir string, dbUpgradePending bool) error {
+func (i *Installer) upgrade(storageDir string) (bool, error) {
 	i.logger.Info("upgrade: restoring database from dump")
 	if err := i.database.Restore(); err != nil {
-		return err
+		return false, err
 	}
 	i.logger.Info("upgrade: database restore done, preparing storage")
 	if err := i.prepareStorage(storageDir); err != nil {
-		return err
+		return false, err
 	}
+	// Only meaningful once the dump is back: post-refresh wipes and re-initdb's
+	// the cluster, so asking before the restore always errors and looks pending.
+	dbUpgradePending := i.NeedsDbUpgrade()
+	i.logger.Info("upgrade: checked schema", zap.Bool("dbUpgradePending", dbUpgradePending))
 	i.logger.Info("upgrade: legacy admin->syncloud ldap mapping fix")
 	if err := i.RunMigrateLegacyAdminLdapGroup(); err != nil {
-		return err
+		return false, err
 	}
 	if dbUpgradePending {
-		i.logger.Info("upgrade: db schema behind code, deferring ldap steps to repair-service")
-		return nil
+		i.logger.Info("upgrade: db schema behind code, handing ldap steps to repair-service")
+		if err := i.MarkLdapDeferred(); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if err := i.ClearLdapDeferred(); err != nil {
+		return false, err
 	}
 	i.logger.Info("upgrade: forcing ldap getGroups via group:list")
 	if err := i.RunGroupList(); err != nil {
-		return err
+		return false, err
 	}
 	i.logger.Info("upgrade: promoting syncloud ldap group")
 	if err := i.RunLdapPromoteSyncloud(); err != nil {
-		return err
+		return false, err
 	}
 	i.logger.Info("upgrade: done (heavy occ steps deferred to repair-service)")
-	return nil
+	return false, nil
 }
 
 func (i *Installer) initialize(storageDir string) error {

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -451,8 +451,19 @@ func (i *Installer) RunGroupList() error {
 	return err
 }
 
+// Something can re-enable maintenance mode between maintenance-mode-off and
+// here (seen in the wild: apps loaded fine one second earlier, then
+// 'no apps are loaded'), which hides the whole ldap namespace.
 func (i *Installer) RunLdapPromoteSyncloud() error {
 	_, err := i.occ.Run("ldap:promote-group", "syncloud", "-y")
+	if err == nil {
+		return nil
+	}
+	i.logger.Info("ldap promote failed, forcing maintenance mode off and retrying", zap.Error(err))
+	if _, offErr := i.occ.Run("maintenance:mode", "--off"); offErr != nil {
+		return err
+	}
+	_, err = i.occ.Run("ldap:promote-group", "syncloud", "-y")
 	return err
 }
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -49,10 +49,15 @@ http {
         # Path to the root of your installation
         root /snap/nextcloud/current/nextcloud;
 
-        error_page 503 /syncloud-maintenance.html;
-        location = /syncloud-maintenance.html {
-            root /snap/nextcloud/current/config;
+        error_page 503 /syncloud-status.html;
+        location = /syncloud-status.html {
+            root /var/snap/nextcloud/current;
             internal;
+            try_files $uri @status_fallback;
+        }
+        location @status_fallback {
+            root /snap/nextcloud/current/config;
+            try_files /syncloud-maintenance.html =503;
         }
 
         # Prevent nginx HTTP Server Detection

--- a/config/syncloud-upgrade-failed.html
+++ b/config/syncloud-upgrade-failed.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Nextcloud upgrade did not finish</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 640px;
+            margin: 0 auto;
+            padding: 40px 20px;
+            text-align: center;
+        }
+        .container {
+            background: #f9f9f9;
+            border-radius: 10px;
+            padding: 40px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #e74c3c;
+            margin-bottom: 20px;
+        }
+        .status-code {
+            background: #e74c3c;
+            color: white;
+            padding: 5px 15px;
+            border-radius: 20px;
+            display: inline-block;
+            font-weight: bold;
+            margin-bottom: 20px;
+        }
+        p {
+            margin-bottom: 20px;
+            font-size: 18px;
+        }
+        .note {
+            font-size: 15px;
+            color: #666;
+        }
+        code {
+            display: block;
+            background: #2c3e50;
+            color: #ecf0f1;
+            padding: 12px 16px;
+            border-radius: 6px;
+            font-size: 15px;
+            text-align: left;
+            overflow-x: auto;
+            margin: 10px 0 20px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container" id="syncloud-nextcloud-upgrade-failed">
+        <div class="status-code">Upgrade failed</div>
+        <h1>Nextcloud upgrade did not finish</h1>
+        <p>Your files are safe, but Nextcloud cannot start until the upgrade is completed.</p>
+        <p class="note">To see which step failed, run this over SSH on your device:</p>
+        <code>snap run nextcloud.repair-status</code>
+        <p class="note">
+            Please send that output to Syncloud support so the upgrade can be finished.
+            Restarting the device will retry the upgrade.
+        </p>
+    </div>
+</body>
+</html>

--- a/test/upgrade.py
+++ b/test/upgrade.py
@@ -12,6 +12,7 @@ MARKER_NAME = 'upgrade-marker.txt'
 MARKER_BODY = b'pre-store-upgrade-marker'
 MAINTENANCE_MARKER = 'syncloud-nextcloud-maintenance'
 UPGRADE_FAILED_MARKER = 'syncloud-nextcloud-upgrade-failed'
+STORE_VERSION = {}
 
 
 @pytest.fixture(scope="session")
@@ -38,6 +39,11 @@ def test_start(module_setup, app, device_host, domain, device):
 def test_install_store(device):
     device.run_ssh('snap remove nextcloud')
     device.run_ssh('snap install nextcloud', retries=10)
+
+
+def test_record_store_version(device):
+    out = device.run_ssh('snap run nextcloud.occ status --output=json')
+    STORE_VERSION['v'] = json.loads(out).get('versionstring')
 
 
 def test_pre_upgrade_write_marker(app_domain, device_user, device_password):
@@ -72,6 +78,12 @@ def test_upgrade(device_host, device_password, app_archive_path):
 
 def test_maintenance_page_visible_during_upgrade(device, app_domain, artifact_dir):
     import time
+    built = device.run_ssh('grep OC_VersionString /snap/nextcloud/current/nextcloud/version.php')
+    store = STORE_VERSION.get('v')
+    if store and store in built:
+        pytest.skip(
+            'store snap is already {0}; a same-version refresh runs no schema '
+            'migration, so there is no 503 window to observe'.format(store))
     session = requests.session()
     deadline = time.time() + 1800
     last_status = None

--- a/test/upgrade.py
+++ b/test/upgrade.py
@@ -11,6 +11,7 @@ TMP_DIR = '/tmp/syncloud'
 MARKER_NAME = 'upgrade-marker.txt'
 MARKER_BODY = b'pre-store-upgrade-marker'
 MAINTENANCE_MARKER = 'syncloud-nextcloud-maintenance'
+UPGRADE_FAILED_MARKER = 'syncloud-nextcloud-upgrade-failed'
 
 
 @pytest.fixture(scope="session")
@@ -124,6 +125,37 @@ def test_post_upgrade_repair_status(device):
 
 def test_post_upgrade_available(app_domain):
     wait_for_rest(requests.session(), "https://{0}".format(app_domain), 200, 10)
+
+
+def test_status_page_cleared_after_success(device):
+    out = device.run_ssh(
+        'ls /var/snap/nextcloud/current/syncloud-status.html 2>&1 || true')
+    assert 'No such file' in out, out
+
+
+def test_upgrade_failed_page_when_repair_gives_up(device, app_domain):
+    import time
+    device.run_ssh('snap run nextcloud.occ maintenance:mode --on')
+    device.run_ssh('echo 99 > /var/snap/nextcloud/current/.repair-attempts')
+    device.run_ssh('touch /var/snap/nextcloud/current/.refresh-needed')
+    device.run_ssh('systemctl restart snap.nextcloud.post-start-repair')
+    try:
+        deadline = time.time() + 180
+        body = ''
+        while time.time() < deadline:
+            r = requests.get('https://{0}/'.format(app_domain), verify=False)
+            body = r.text
+            if UPGRADE_FAILED_MARKER in body:
+                assert r.status_code == 503, r.status_code
+                return
+            time.sleep(5)
+        raise AssertionError('upgrade-failed page never served, last body: ' + body[:500])
+    finally:
+        device.run_ssh('rm -f /var/snap/nextcloud/current/.repair-attempts', throw=False)
+        device.run_ssh('rm -f /var/snap/nextcloud/current/.refresh-needed', throw=False)
+        device.run_ssh('rm -f /var/snap/nextcloud/current/syncloud-status.html', throw=False)
+        device.run_ssh('snap run nextcloud.occ maintenance:mode --off', throw=False)
+        device.run_ssh('systemctl restart snap.nextcloud.post-start-repair', throw=False)
 
 
 def test_post_upgrade_marker_survives(app_domain, device_user, device_password):

--- a/test/upgrade.py
+++ b/test/upgrade.py
@@ -145,31 +145,6 @@ def test_status_page_cleared_after_success(device):
     assert 'No such file' in out, out
 
 
-def test_upgrade_failed_page_when_repair_gives_up(device, app_domain):
-    import time
-    device.run_ssh('snap run nextcloud.occ maintenance:mode --on')
-    device.run_ssh('echo 99 > /var/snap/nextcloud/current/.repair-attempts')
-    device.run_ssh('touch /var/snap/nextcloud/current/.refresh-needed')
-    device.run_ssh('systemctl restart snap.nextcloud.post-start-repair')
-    try:
-        deadline = time.time() + 180
-        body = ''
-        while time.time() < deadline:
-            r = requests.get('https://{0}/'.format(app_domain), verify=False)
-            body = r.text
-            if UPGRADE_FAILED_MARKER in body:
-                assert r.status_code == 503, r.status_code
-                return
-            time.sleep(5)
-        raise AssertionError('upgrade-failed page never served, last body: ' + body[:500])
-    finally:
-        device.run_ssh('rm -f /var/snap/nextcloud/current/.repair-attempts', throw=False)
-        device.run_ssh('rm -f /var/snap/nextcloud/current/.refresh-needed', throw=False)
-        device.run_ssh('rm -f /var/snap/nextcloud/current/syncloud-status.html', throw=False)
-        device.run_ssh('snap run nextcloud.occ maintenance:mode --off', throw=False)
-        device.run_ssh('systemctl restart snap.nextcloud.post-start-repair', throw=False)
-
-
 def test_post_upgrade_marker_survives(app_domain, device_user, device_password):
     r = requests.get(
         'https://{0}/remote.php/webdav/{1}'.format(app_domain, MARKER_NAME),
@@ -197,3 +172,28 @@ def test_post_upgrade_admin_can_list_users(app_domain, device_user, device_passw
     assert r.status_code == 200, r.text
     meta = r.json()['ocs']['meta']
     assert meta['statuscode'] == 100, r.text
+
+
+def test_upgrade_failed_page_when_repair_gives_up(device, app_domain):
+    import time
+    device.run_ssh('snap run nextcloud.occ maintenance:mode --on')
+    device.run_ssh('echo 99 > /var/snap/nextcloud/current/.repair-attempts')
+    device.run_ssh('touch /var/snap/nextcloud/current/.refresh-needed')
+    device.run_ssh('systemctl restart snap.nextcloud.post-start-repair')
+    try:
+        deadline = time.time() + 180
+        body = ''
+        while time.time() < deadline:
+            r = requests.get('https://{0}/'.format(app_domain), verify=False)
+            body = r.text
+            if UPGRADE_FAILED_MARKER in body:
+                assert r.status_code == 503, r.status_code
+                return
+            time.sleep(5)
+        raise AssertionError('upgrade-failed page never served, last body: ' + body[:500])
+    finally:
+        device.run_ssh('rm -f /var/snap/nextcloud/current/.repair-attempts', throw=False)
+        device.run_ssh('rm -f /var/snap/nextcloud/current/.refresh-needed', throw=False)
+        device.run_ssh('rm -f /var/snap/nextcloud/current/syncloud-status.html', throw=False)
+        device.run_ssh('snap run nextcloud.occ maintenance:mode --off', throw=False)
+        device.run_ssh('systemctl restart snap.nextcloud.post-start-repair', throw=False)


### PR DESCRIPTION
Fixes the 8-hour "Nextcloud is upgrading" report in [forum #665](https://syncloud.discourse.group/t/update-request-nextcloud/665/4).

## Root cause

Alex's `repair-status` shows it exactly:

| step | time | result |
|---|---|---|
| occ-upgrade | 20:36:43 | ok, 83.4s |
| maintenance-mode-off | 20:38:07 | ok |
| ldap-set-email-attribute | 20:38:10 | ok — an `ldap:*` command, so apps **were** loaded |
| group-list | 20:38:11 | ok |
| **ldap-promote-syncloud** | 20:38:12 | **`Nextcloud is in maintenance mode, no apps are loaded`** |
| db-add-missing-* / maintenance-repair | 20:38:13+ | ok |
| | | `done: true` |

Maintenance mode was off at 20:38:10 and back on one second later. The daemon recorded the error, carried on, reported done, and **nothing turned maintenance mode off again** — so nextcloud served 503 indefinitely. He recovered by hand with `occ maintenance:repair --include-expensive` and a restart.

The maintenance page made it worse: it is driven purely by nextcloud answering 503, so it cannot tell "migrating" from "wedged", and showed a spinner and *"please leave the device powered on"* for 8 hours. Before that page existed he would have seen nextcloud's own *Update needed* screen — uglier, but honest. CI never caught it because CI only exercises the success path.

## Changes

- **Never leave the app down.** The repair sequence always ends with `maintenance-mode-off`, whatever failed above it. A failed ldap promotion is cosmetic; maintenance mode takes the whole app offline.
- **Promote retries once** after forcing maintenance mode off, addressing the race directly.
- **The page tells the truth.** The daemon writes the upgrading page when it starts work, replaces it with an upgrade-failed page if any step errors, and clears it on success. nginx serves `$SNAP_DATA/syncloud-status.html` for 503 with a fallback to the bundled page. The failure page names `snap run nextcloud.repair-status` as the next step.
- **Bounded retries.** `restart-condition: always` means a crashing `occ upgrade` would re-run forever behind a reassuring page. Attempts are capped at 3, then the failure page shows.

## Does this heal stuck users automatically?

Yes, and the retry is what makes it work. A stuck user has `'maintenance' => true` in `config.php`, which survives the refresh. On the next auto-refresh `configure` reaches `ldap:promote-group`, which fails in maintenance mode and **returns an error — failing the whole refresh and rolling it back**, leaving them stuck forever. With the retry, maintenance mode is forced off and the promote succeeds, so the refresh completes and the app comes back. No user action needed.

Users whose `occ upgrade` genuinely failed still need help, but now get a page naming the failing step instead of a spinner.

## Tests

- asserts the status page is cleared after a successful upgrade
- drives the give-up path for real: maintenance mode on for a genuine 503, attempts past the cap, service restarted, then asserts the failure page is served with 503. Runs last so it cannot disturb the suite.
- the maintenance-page visibility assertion is skipped on a same-version refresh, since no schema migration means no 503 window. It only ever held while the store was on 32.

## Known red build — pre-existing, not from this PR

`test_post_upgrade_admin_can_list_users` fails with 403. I re-ran **unmodified master `365af8b`** against today's store as a control (build 988) and it **fails identically**. Now that the store serves 33.0.7, `test-upgrade` is a same-version refresh, which runs the ldap promote in `Configure` rather than the daemon, and the promotion does not stick — consistent with 9189d7d4's note that Configure's later `ldap:set-config` invalidates the ldap backend cache.

That is a real pre-existing bug (legacy-mapping users lose admin on a routine refresh) but it is not caused by this PR, and it is tracked separately.