### PR TITLE
let a failing app be disabled instead of blocking the upgrade

### DIFF
--- a/cli/cmd/repair-service/main.go
+++ b/cli/cmd/repair-service/main.go
@@ -65,7 +65,6 @@ func main() {
 				step{"db-add-missing-columns", inst.RunDbAddMissingColumns},
 				step{"db-add-missing-primary-keys", inst.RunDbAddMissingPrimaryKeys},
 				step{"maintenance-repair", inst.RunMaintenanceRepair},
-				step{"maintenance-mode-off-final", inst.RunMaintenanceModeOff},
 			)
 		} else {
 			logger.Info("refresh-needed marker absent; skipping heavy post-refresh repair")
@@ -88,12 +87,32 @@ func main() {
 		}
 
 		failed := false
+		coreConsistent := true
 		for _, s := range steps {
 			done := srv.StartStep(s.name)
 			err := s.fn()
 			done(err)
 			if err != nil {
 				failed = true
+				if s.name == "occ-upgrade" {
+					coreConsistent = false
+				}
+			}
+		}
+		if len(steps) > 0 {
+			if coreConsistent {
+				done := srv.StartStep("maintenance-mode-off-final")
+				err := inst.RunMaintenanceModeOff()
+				done(err)
+				if err != nil {
+					failed = true
+				}
+			} else {
+				logger.Error("core upgrade failed; leaving maintenance mode on rather than exposing a half-upgraded instance")
+			}
+			if apps := inst.DisabledApps(); len(apps) > 0 {
+				logger.Info("apps disabled to let the upgrade through", zap.Strings("apps", apps))
+				srv.SetDisabledApps(apps)
 			}
 		}
 		if len(steps) > 0 {

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -26,15 +26,17 @@ const (
 	DbPassword = "nextcloud"
 	PsqlPort   = 5436
 
-	SignalingSecretsFile = "signaling.secrets"
-	ConfigureDoneMarker  = ".configure-done"
-	RefreshNeededMarker  = ".refresh-needed"
-	RepairAttemptsFile   = ".repair-attempts"
-	LdapDeferredMarker   = ".ldap-deferred"
-	StatusPageFile       = "syncloud-status.html"
-	UpgradingPage        = "syncloud-maintenance.html"
-	UpgradeFailedPage    = "syncloud-upgrade-failed.html"
-	MaxRepairAttempts    = 3
+	SignalingSecretsFile  = "signaling.secrets"
+	ConfigureDoneMarker   = ".configure-done"
+	RefreshNeededMarker   = ".refresh-needed"
+	RepairAttemptsFile    = ".repair-attempts"
+	LdapDeferredMarker    = ".ldap-deferred"
+	StatusPageFile        = "syncloud-status.html"
+	UpgradingPage         = "syncloud-maintenance.html"
+	UpgradeFailedPage     = "syncloud-upgrade-failed.html"
+	MaxRepairAttempts     = 3
+	MaxAppDisableAttempts = 3
+	DisabledAppsFile      = ".disabled-apps"
 )
 
 type Variables struct {
@@ -52,21 +54,21 @@ type Variables struct {
 }
 
 type Installer struct {
-	appDir              string
-	commonDir           string
-	dataDir             string
-	configDir           string
-	extraAppsDir        string
-	ncConfigPath        string
-	ncConfigFile        string
+	appDir               string
+	commonDir            string
+	dataDir              string
+	configDir            string
+	extraAppsDir         string
+	ncConfigPath         string
+	ncConfigFile         string
 	signalingSecretsPath string
-	platformClient      *platform.Client
-	executor            *Executor
-	database            *Database
-	occ                 *OCConsole
-	ocConfig            *OCConfig
-	cron                *Cron
-	logger              *zap.Logger
+	platformClient       *platform.Client
+	executor             *Executor
+	database             *Database
+	occ                  *OCConsole
+	ocConfig             *OCConfig
+	cron                 *Cron
+	logger               *zap.Logger
 }
 
 func New(logger *zap.Logger) *Installer {
@@ -429,8 +431,80 @@ func (i *Installer) WaitForConfigureDone(timeout time.Duration) error {
 }
 
 func (i *Installer) RunOccUpgrade() error {
-	_, err := i.occ.Run("upgrade")
+	out, err := i.occ.Run("upgrade")
+	if err == nil {
+		return nil
+	}
+	for attempt := 0; attempt < MaxAppDisableAttempts; attempt++ {
+		app := failingApp(out)
+		if app == "" {
+			i.logger.Error("upgrade failed and no app could be blamed", zap.Error(err))
+			return err
+		}
+		i.logger.Info("app blocked the upgrade, disabling it and retrying", zap.String("app", app))
+		if _, offErr := i.occ.Run("maintenance:mode", "--off"); offErr != nil {
+			return err
+		}
+		if _, disErr := i.occ.Run("app:disable", app); disErr != nil {
+			i.logger.Error("cannot disable app", zap.String("app", app), zap.Error(disErr))
+			return err
+		}
+		i.recordDisabledApp(app)
+		out, err = i.occ.Run("upgrade")
+		if err == nil {
+			i.logger.Info("upgrade completed with app disabled", zap.String("app", app))
+			return nil
+		}
+	}
 	return err
+}
+
+var appUpgradeStarted = regexp.MustCompile(`Updating <([^>]+)> \.\.\.`)
+var appUpgradeFinished = regexp.MustCompile(`Updated <([^>]+)> to `)
+var appSchemaChecked = regexp.MustCompile(`database schema for <([^>]+)> can be updated`)
+
+func failingApp(out string) string {
+	finished := map[string]bool{}
+	for _, m := range appUpgradeFinished.FindAllStringSubmatch(out, -1) {
+		finished[m[1]] = true
+	}
+	var started []string
+	for _, re := range []*regexp.Regexp{appUpgradeStarted, appSchemaChecked} {
+		for _, m := range re.FindAllStringSubmatch(out, -1) {
+			started = append(started, m[1])
+		}
+	}
+	for n := len(started) - 1; n >= 0; n-- {
+		if !finished[started[n]] {
+			return started[n]
+		}
+	}
+	return ""
+}
+
+func (i *Installer) recordDisabledApp(app string) {
+	p := path.Join(i.dataDir, DisabledAppsFile)
+	existing, _ := os.ReadFile(p)
+	if strings.Contains(string(existing), app+"\n") {
+		return
+	}
+	if err := os.WriteFile(p, append(existing, []byte(app+"\n")...), 0644); err != nil {
+		i.logger.Error("cannot record disabled app", zap.String("app", app), zap.Error(err))
+	}
+}
+
+func (i *Installer) DisabledApps() []string {
+	data, err := os.ReadFile(path.Join(i.dataDir, DisabledAppsFile))
+	if err != nil {
+		return nil
+	}
+	var apps []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if line != "" {
+			apps = append(apps, line)
+		}
+	}
+	return apps
 }
 
 func (i *Installer) RunMaintenanceModeOff() error {

--- a/cli/installer/installer_test.go
+++ b/cli/installer/installer_test.go
@@ -1,0 +1,49 @@
+package installer
+
+import "testing"
+
+func TestFailingAppIsTheOneThatStartedAndNeverFinished(t *testing.T) {
+	out := `Turned on maintenance mode
+Updating database schema
+Updated database
+Checking whether the database schema for <calendar> can be updated (this can take a long time depending on the database size)
+Updating <calendar> ...
+Updated <calendar> to 5.0.1
+Checking whether the database schema for <contacts> can be updated (this can take a long time depending on the database size)
+Updating <contacts> ...
+Doctrine\DBAL\Exception: An exception occurred while executing a query
+Maintenance mode is kept active`
+
+	if got := failingApp(out); got != "contacts" {
+		t.Fatalf("expected contacts, got %q", got)
+	}
+}
+
+func TestFailingAppWhenSchemaCheckItselfFails(t *testing.T) {
+	out := `Turned on maintenance mode
+Checking whether the database schema for <calendar> can be updated (this can take a long time depending on the database size)
+Doctrine\DBAL\Exception: not able to migrate
+Maintenance mode is kept active`
+
+	if got := failingApp(out); got != "calendar" {
+		t.Fatalf("expected calendar, got %q", got)
+	}
+}
+
+func TestNoFailingAppWhenEveryAppFinished(t *testing.T) {
+	out := `Updating <calendar> ...
+Updated <calendar> to 5.0.1
+Updating <contacts> ...
+Updated <contacts> to 6.0.0
+Doctrine\DBAL\Exception: core migration failed`
+
+	if got := failingApp(out); got != "" {
+		t.Fatalf("expected no app to be blamed, got %q", got)
+	}
+}
+
+func TestNoFailingAppWhenOutputMentionsNoApps(t *testing.T) {
+	if got := failingApp("No upgrade required."); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+}

--- a/cli/repair/repair.go
+++ b/cli/repair/repair.go
@@ -26,6 +26,7 @@ type Status struct {
 	StartedAt     time.Time `json:"started_at"`
 	ConfigureDone bool      `json:"configure_done"`
 	Steps         []Step    `json:"steps"`
+	DisabledApps  []string  `json:"disabled_apps,omitempty"`
 	Done          bool      `json:"done"`
 }
 
@@ -69,6 +70,12 @@ func (s *Server) StartStep(name string) func(error) {
 			s.logger.Info("step end", zap.String("name", name), zap.Duration("took", took))
 		}
 	}
+}
+
+func (s *Server) SetDisabledApps(apps []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status.DisabledApps = apps
 }
 
 func (s *Server) MarkDone() {


### PR DESCRIPTION
Follow-up to #15. Makes app failures non-fatal to the nextcloud upgrade, as requested: nextcloud gets upgraded, and an app that cannot migrate is parked rather than taking the whole instance down.

## Why

`occ upgrade` **does** upgrade apps (`doAppUpgrade()` inside `doUpgrade()`), and any exception there fails the whole upgrade. Nextcloud then keeps maintenance mode on **on purpose**:

```php
if (!$wasMaintenanceModeEnabled && $success) {
    setSystemValue('maintenance', false);   // off only on success
} else {
    emit('maintenanceActive');              // deliberately LEFT ON
}
```

So one broken app = instance offline. Nextcloud's own code spells out the manual recovery it expects:

```php
} elseif ($this->config->getSystemValueBool('maintenance')) {
    //Possible scenario: Nextcloud core is updated but an app failed
    ... 'remove the "maintenance mode" from config.php and call this script again'
    return self::ERROR_MAINTENANCE_MODE;   // exit 2
}
```

This PR automates that recovery.

## What it does

On a failed `occ upgrade`:

1. blame the app that started migrating and never finished (`Updating <app> ...` / `Checking whether the database schema for <app> can be updated` with no matching `Updated <app> to …`)
2. clear maintenance mode — a retry is refused with exit 2 otherwise
3. `occ app:disable <app>`
4. re-run `occ upgrade`

Up to three apps. Core reaches a consistent state; the broken app is disabled.

Disabled apps are recorded and reported in `repair-status` as `disabled_apps`, so this is visible rather than an app silently vanishing.

## Corrects an overreach in #15

#15 made `maintenance-mode-off-final` unconditional, which overrode nextcloud's deliberate refusal to expose a half-migrated instance. It is now conditional on the core upgrade having succeeded:

- **app failed** → app disabled, core consistent, instance comes up
- **core genuinely failed** → maintenance mode stays on, upgrade-failed page shown, instance correctly stays down

## Tests

`failingApp` is unit tested (`cli/installer/installer_test.go`) against real `occ upgrade` output shapes: an app that never finished, a schema check that failed before the `Updating` line, output where every app completed so core is to blame, and `No upgrade required.`

## Context

Alex's calendar app showed *"not able to migrate"* during his 32→33 upgrade (forum 665, post 12). Note his `occ-upgrade` step recorded **no error**, so that upgrade did succeed and the app problem was not what wedged his instance — the trigger for maintenance mode being re-enabled mid-sequence is still unknown. This PR addresses the failure mode his calendar issue points at, not the one he actually hit.