### PR TITLE
disable apps that fail to load after an upgrade

### DIFF
--- a/cli/cmd/repair-service/main.go
+++ b/cli/cmd/repair-service/main.go
@@ -65,6 +65,7 @@ func main() {
 				step{"db-add-missing-columns", inst.RunDbAddMissingColumns},
 				step{"db-add-missing-primary-keys", inst.RunDbAddMissingPrimaryKeys},
 				step{"maintenance-repair", inst.RunMaintenanceRepair},
+				step{"disable-broken-apps", inst.RunDisableBrokenApps},
 			)
 		} else {
 			logger.Info("refresh-needed marker absent; skipping heavy post-refresh repair")

--- a/cli/installer/installer.go
+++ b/cli/installer/installer.go
@@ -483,6 +483,42 @@ func failingApp(out string) string {
 	return ""
 }
 
+func (i *Installer) RunDisableBrokenApps() error {
+	out, err := i.occ.Run("app:list")
+	if err == nil {
+		return nil
+	}
+	for attempt := 0; attempt < MaxAppDisableAttempts; attempt++ {
+		app := brokenApp(out)
+		if app == "" {
+			i.logger.Error("apps fail to load and no app could be blamed", zap.Error(err))
+			return err
+		}
+		i.logger.Info("app fails to load, disabling it", zap.String("app", app))
+		if _, disErr := i.occ.Run("app:disable", app); disErr != nil {
+			i.logger.Error("cannot disable app", zap.String("app", app), zap.Error(disErr))
+			return err
+		}
+		i.recordDisabledApp(app)
+		out, err = i.occ.Run("app:list")
+		if err == nil {
+			i.logger.Info("apps load again with app disabled", zap.String("app", app))
+			return nil
+		}
+	}
+	return err
+}
+
+var brokenAppPath = regexp.MustCompile(`/(?:extra-apps|apps)/([a-z0-9_]+)/(?:lib|appinfo)/`)
+
+func brokenApp(out string) string {
+	m := brokenAppPath.FindStringSubmatch(out)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
 func (i *Installer) recordDisabledApp(app string) {
 	p := path.Join(i.dataDir, DisabledAppsFile)
 	existing, _ := os.ReadFile(p)

--- a/cli/installer/installer_test.go
+++ b/cli/installer/installer_test.go
@@ -47,3 +47,35 @@ func TestNoFailingAppWhenOutputMentionsNoApps(t *testing.T) {
 		t.Fatalf("expected empty, got %q", got)
 	}
 }
+
+func TestBrokenAppFromExtraAppsPath(t *testing.T) {
+	out := `An unhandled exception has been thrown:
+Error: Call to undefined method OC\Server::getContentSecurityPolicyManager() in ` +
+		`/var/snap/nextcloud/1011/extra-apps/radio/lib/AppInfo/Application.php:24`
+
+	if got := brokenApp(out); got != "radio" {
+		t.Fatalf("expected radio, got %q", got)
+	}
+}
+
+func TestBrokenAppFromBundledAppPath(t *testing.T) {
+	out := `Exception: Call to undefined method OC\Server::getURLGenerator() in file ` +
+		`'/var/snap/nextcloud/1011/extra-apps/quicknotes/lib/AppInfo/Application.php' line 70`
+
+	if got := brokenApp(out); got != "quicknotes" {
+		t.Fatalf("expected quicknotes, got %q", got)
+	}
+}
+
+func TestBrokenAppFromAppinfoPath(t *testing.T) {
+	out := `Error in /snap/nextcloud/current/nextcloud/apps/files_rightclick/appinfo/app.php`
+	if got := brokenApp(out); got != "files_rightclick" {
+		t.Fatalf("expected files_rightclick, got %q", got)
+	}
+}
+
+func TestNoBrokenAppWhenOutputHasNoAppPath(t *testing.T) {
+	if got := brokenApp("Doctrine\\DBAL\\Exception: database is gone"); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+}

--- a/test/upgrade.py
+++ b/test/upgrade.py
@@ -117,6 +117,7 @@ def test_post_upgrade_repair_status(device):
         'db-add-missing-columns',
         'db-add-missing-primary-keys',
         'maintenance-repair',
+        'disable-broken-apps',
     ]
     deadline = time.time() + 1800
     last = ''


### PR DESCRIPTION
A user's Nextcloud returned **500 on every request** after upgrading to 34. His log (pulled from the raw device report) shows two third-party apps calling `OC\Server` methods that 34 removed:

| app | error | count |
| --- | --- | --- |
| `radio` | `Call to undefined method OC\Server::getContentSecurityPolicyManager()` — `extra-apps/radio/lib/AppInfo/Application.php` | 21x, **level 4** |
| `quicknotes` | `Call to undefined method OC\Server::getURLGenerator()` — `extra-apps/quicknotes/lib/AppInfo/Application.php:70` | thrown on `GET /login` |

Nextcloud bootstraps every enabled app on each request, so one app throwing during bootstrap takes the whole request down. It was not just the web UI — the same fatal appears on `PROPFIND /remote.php/dav/...` (9x) and `/ocs/v2.php` (9x), so **file sync and mobile clients were broken too**.

This is the same class of bug as the `getConfig()` removal that broke our own config tool on 34. Ours we fixed; third-party apps we cannot.

## Why the existing handling missed it

The app-disable path added earlier only triggers when **`occ upgrade` fails**. These apps upgrade cleanly and then throw at *runtime*, on every request. Nothing noticed, and the user got a bare 500 pointing nowhere near the cause.

## Change

A `disable-broken-apps` step at the end of the repair sequence: run `occ app:list` as a probe, and if loading apps fails, blame the app from the `extra-apps/<app>/` or `apps/<app>/` path in the error, disable it, and retry. Up to three apps, reusing the existing recording so they surface in `repair-status` as `disabled_apps`.

**`occ` is a valid probe here** — not an assumption. The same fatal appears in his log with `method=CLI` from `cron.php`, so PHP-side bootstrap hits it too rather than it being web-only.

## Tests

`brokenApp` is unit tested against the exact error strings from that report — extra-apps path, bundled apps path, `appinfo/app.php` form, and output with no app path at all. `test/upgrade.py` asserts the new step runs and reports no error.

## Limitation worth naming

The probe catches apps that fatal hard enough to break `occ`. An app that breaks only a specific web route, or only under a session, would still slip through. Catching those would need a real authenticated request, which is a bigger design change and not attempted here.
